### PR TITLE
Improve Data.Binary.Builder performance for loops

### DIFF
--- a/src/Data/Binary/Builder.hs
+++ b/src/Data/Binary/Builder.hs
@@ -102,6 +102,8 @@ instance Monoid Builder where
     {-# INLINE mempty #-}
     mappend = append
     {-# INLINE mappend #-}
+    mconcat = foldr mappend mempty
+    {-# INLINE mconcat #-}
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
These two changes improve performance of loops by a great deal under GHC 7.0.2. Here's a benchmark from blaze-binary's benchmark suite:

Before:

```
benchmarking [Word8] (Data.Binary builder)
mean: 270.0117 us, lb 268.7389 us, ub 271.5027 us, ci 0.950
std dev: 7.068080 us, lb 6.076107 us, ub 8.467179 us, ci 0.950
```

After:

```
benchmarking [Word8] (Data.Binary builder)
mean: 54.53609 us, lb 54.40396 us, ub 54.73913 us, ci 0.950
std dev: 828.4616 ns, lb 592.5139 ns, ub 1.134636 us, ci 0.950
```
