### PR TITLE
README updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The ``binary`` package provides Data.Binary, containing the Binary class,
 and associated methods, for serialising values to and from lazy
 ByteStrings. 
 A key feature of ``binary`` is that the interface is both pure, and efficient.
-The 'binary' package is portable to GHC and Hugs.
+The ``binary`` package is portable to GHC and Hugs.
 
 ## Building binary ##
 


### PR DESCRIPTION
I rewrote the README file to use the markdown format (with a .md extension). This makes its display in the GitHub page much nicer.

Also, I added a little bit more of information, like installing the `binary` package using cabal-install or where to find the example of how to define a Binary instance.

The text remains legible when reading it as plain text.
