### PR TITLE
Implement `isolate` for reading fixed-size blocks.

### DIFF
--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -144,6 +144,7 @@ module Data.Binary.Get (
     , skip
     , isEmpty
     , bytesRead
+    , isolate
     , lookAhead
     , lookAheadM
     , lookAheadE


### PR DESCRIPTION
Closes #32
