### PR TITLE
Added function to conveniently check for presence of fixed values.

### DIFF
--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -159,6 +159,7 @@ module Data.Binary.Get (
     -- * Decoding
     , skip
     , isEmpty
+    , expect
     , bytesRead
     , lookAhead
     , lookAheadM
@@ -357,6 +358,11 @@ pushEndOfInput r =
     Done _ _ _ -> r
     Partial k -> k Nothing
     Fail _ _ _ -> r
+
+-- | Read a value from the monad state, failing if the read value does not
+-- match the argument value.
+expect :: (Eq a, Binary a) => a -> Get a
+expect x = get >>= \y -> if x == y then return x else empty
 
 -- | An efficient get method for lazy ByteStrings. Fails if fewer than @n@
 -- bytes are left in the input.


### PR DESCRIPTION
Many binary formats have sentinel values/delimiters and binary currently does not provide a convenient way to check for these. Added a simple function that compares the parsed value with an expected value.
