### PR TITLE
Binary instances for NaN and negative zero are broken

### DIFF
--- a/binary.cabal
+++ b/binary.cabal
@@ -71,7 +71,9 @@ test-suite qc
     random>=1.0.1.0,
     test-framework,
     test-framework-quickcheck2 >= 0.3,
-    QuickCheck>=2.5
+    test-framework-hunit,
+    QuickCheck>=2.5,
+    HUnit
 
   ghc-options: -Wall -O2
   hs-source-dirs: src


### PR DESCRIPTION
Roundtripping `(decode . encode)` NaN yields -∞ for both Float and Double and roundtripping negative zero gives oridinary zero. 

This pull request only add tests for transfinite floating point values and does nothing to address issue. It's unclear to me whether it's possible to fix this without breaking encoding format in backward incompatible way.
