### PR TITLE
[fix] preprocessor errors on clang ghc 7.6.3

### DIFF
--- a/src/Data/Binary/Builder/Base.hs
+++ b/src/Data/Binary/Builder/Base.hs
@@ -508,7 +508,5 @@ shiftr_w64 = shiftR
     append (ensureFree a) (ensureFree b) = ensureFree (max a b)
 
 "flush/flush"
-    append flush flush = flush
-
- #-}
+    append flush flush = flush #-}
 #endif

--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -435,8 +435,7 @@ getWord8 = readN 1 B.unsafeHead
 "getWord32be/readN" getWord32be = readN 4 word32be
 "getWord32le/readN" getWord32le = readN 4 word32le
 "getWord64be/readN" getWord64be = readN 8 word64be
-"getWord64le/readN" getWord64le = readN 8 word64le
- #-}
+"getWord64le/readN" getWord64le = readN 8 word64le #-}
 
 -- | Read a Word16 in big endian format
 getWord16be :: Get Word16

--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -321,8 +321,7 @@ readN !n f = ensureN n >> unsafeReadN n f
   returnG f = readN 0 (const f)
 
 "readN 0/returnG swapback" [1] forall f.
-  readN 0 f = returnG (f B.empty)
- #-}
+  readN 0 f = returnG (f B.empty) #-}
 
 -- | Ensure that there are at least @n@ bytes available. If not, the
 -- computation will escape with 'Partial'.


### PR DESCRIPTION
fixes preprocessor errors on os x 10.9.1 running haskell platform with [clang wrapper from Mark L](https://gist.github.com/mzero/7245290) ghc 7.6.3
