### PR TITLE
Add LANGUAGE extensions for inferred signatures.

### DIFF
--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, RankNTypes, MagicHash, BangPatterns #-}
+{-# LANGUAGE CPP, RankNTypes, MagicHash, BangPatterns, TypeFamilies #-}
 
 -- CPP C style pre-precessing, the #if defined lines
 -- RankNTypes forall r. statement


### PR DESCRIPTION
This follows changes in latest HEAD. GHC now checks that language extensions required for inferred type signatures are actually enabled.
