### PR TITLE
Use explicit import-list for `GHC.Base` import

### DIFF
--- a/src/Data/Binary/Builder/Base.hs
+++ b/src/Data/Binary/Builder/Base.hs
@@ -81,7 +81,7 @@ import qualified Data.ByteString.Lazy.Internal as L
 #endif
 
 #if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
-import GHC.Base
+import GHC.Base (ord,Int(..),uncheckedShiftRL#)
 import GHC.Word (Word32(..),Word16(..),Word64(..))
 # if WORD_SIZE_IN_BITS < 64
 import GHC.Word (uncheckedShiftRL64#)


### PR DESCRIPTION
`base` is currently being restructured in GHC HEAD which will very likely
break this unqualified `GHC.Base` import. So this simple change will make
that import statement future-proof.
