### PR TITLE
Optimize roll by using foldl' instead of foldr

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -53,7 +53,7 @@ import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as L
 
 import Data.Char    (ord)
-import Data.List    (unfoldr)
+import Data.List    (unfoldr, foldl')
 
 -- And needed for the instances:
 import qualified Data.ByteString as B
@@ -249,9 +249,9 @@ unroll = unfoldr step
     step i = Just (fromIntegral i, i `shiftR` 8)
 
 roll :: (Integral a, Num a, Bits a) => [Word8] -> a
-roll   = foldr unstep 0
+roll   = foldl' unstep 0 . reverse
   where
-    unstep b a = a `shiftL` 8 .|. fromIntegral b
+    unstep a b = a `shiftL` 8 .|. fromIntegral b
 
 #ifdef HAS_NATURAL
 -- Fixed-size type for a subset of Natural


### PR DESCRIPTION
Regarding #85.

The "roll" benchmarks in the get executable show the difference:

```
get roll
benchmarking roll/foldr
time                 547.4 ms   (537.8 ms .. 553.5 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 549.4 ms   (547.2 ms .. 550.4 ms)
std dev              1.857 ms   (0.0 s .. 1.896 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking roll/foldl'
time                 434.7 ms   (426.4 ms .. 443.1 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 433.7 ms   (432.3 ms .. 434.7 ms)
std dev              1.472 ms   (0.0 s .. 1.696 ms)
variance introduced by outliers: 19% (moderately inflated)
```

The "Integer/decode" benchmark shows the actual decoding speed.
First the old implementation based on `foldr`:

```
get Integer/decode
benchmarking Integer/decode
time                 552.9 ms   (540.2 ms .. 569.3 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 558.2 ms   (556.1 ms .. 559.3 ms)
std dev              1.824 ms   (0.0 s .. 1.906 ms)
variance introduced by outliers: 19% (moderately inflated)
```

The new implementation based on `foldl'`:

```
get Integer/decode
benchmarking Integer/decode
time                 457.5 ms   (406.2 ms .. 505.6 ms)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 455.9 ms   (448.3 ms .. 462.3 ms)
std dev              10.11 ms   (0.0 s .. 11.02 ms)
variance introduced by outliers: 19% (moderately inflated)
```