### PR TITLE
Add Binary Void instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
  - cabal update
  - cabal sandbox init
 # can't use "cabal install --only-dependencies --enable-tests --enable-benchmarks" due to dep-cycle
- - cabal install criterion deepseq mtl "QuickCheck >= 2.8" HUnit "test-framework-quickcheck2 >= 0.3" "random >= 1.0.1.0" attoparsec cereal 'Cabal == 1.22.*' tar zlib -j
+ - cabal install criterion deepseq mtl "QuickCheck >= 2.8" HUnit "test-framework-quickcheck2 >= 0.3" "random >= 1.0.1.0" attoparsec cereal 'Cabal == 1.22.*' tar zlib void -j
 
 script:
  - cabal configure --enable-tests --enable-benchmarks -v2 --ghc-options=-fno-spec-constr

--- a/binary.cabal
+++ b/binary.cabal
@@ -50,7 +50,7 @@ library
       -- prior to ghc-7.4 generics lived in ghc-prim
       build-depends: ghc-prim
 
-  if impl(ghc <= 7.8)
+  if impl(ghc < 7.9)
     -- Data.Void was moved to base for 7.10
     build-depends: void
 

--- a/binary.cabal
+++ b/binary.cabal
@@ -50,6 +50,10 @@ library
       -- prior to ghc-7.4 generics lived in ghc-prim
       build-depends: ghc-prim
 
+  if impl(ghc <= 7.8)
+    -- Data.Void was moved to base for 7.10
+    build-depends: void
+
   ghc-options:     -O2 -Wall -fliberate-case-threshold=1000
 
 -- Due to circular dependency, we cannot make any of the test-suites or

--- a/binary.cabal
+++ b/binary.cabal
@@ -77,7 +77,7 @@ test-suite qc
     QuickCheck>=2.8
 
   -- build dependencies from using binary source rather than depending on the library
-  build-depends: array, containers
+  build-depends: array, containers, void
   ghc-options: -Wall -O2 -threaded
 
 test-suite read-write-file
@@ -93,7 +93,7 @@ test-suite read-write-file
     HUnit
 
   -- build dependencies from using binary source rather than depending on the library
-  build-depends: array, containers
+  build-depends: array, containers, void
   ghc-options: -Wall
 
 benchmark bench
@@ -105,7 +105,7 @@ benchmark bench
     base >= 3.0 && < 5,
     bytestring
   -- build dependencies from using binary source rather than depending on the library
-  build-depends: array, containers
+  build-depends: array, containers, void
   c-sources: benchmarks/CBenchmark.c
   include-dirs: benchmarks
   ghc-options: -O2
@@ -123,7 +123,7 @@ benchmark get
     deepseq,
     mtl
   -- build dependencies from using binary source rather than depending on the library
-  build-depends: array, containers
+  build-depends: array, containers, void
   ghc-options: -O2 -Wall
 
 benchmark generics-bench
@@ -144,7 +144,7 @@ benchmark generics-bench
     GenericsBenchCache
     GenericsBenchTypes
   -- build dependencies from using binary source rather than depending on the library
-  build-depends: array, containers
+  build-depends: array, containers, void
   ghc-options: -O2 -Wall
   if impl(ghc >= 7.2.1)
     cpp-options: -DGENERICS
@@ -164,5 +164,5 @@ benchmark builder
     deepseq,
     mtl
   -- build dependencies from using binary source rather than depending on the library
-  build-depends: array, containers
+  build-depends: array, containers, void
   ghc-options: -O2

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -43,6 +43,7 @@ module Data.Binary.Class (
 import Data.Word
 import Data.Bits
 import Data.Int
+import Data.Void
 
 import Data.Binary.Put
 import Data.Binary.Get
@@ -127,6 +128,12 @@ class Binary t where
 
 ------------------------------------------------------------------------
 -- Simple instances
+
+-- Void never gets written nor reconstructed since it's impossible to have a
+-- value of that type
+instance Binary Void where
+    put     = absurd
+    get     = mzero
 
 -- The () type need never be written to disk: values of singleton type
 -- can be reconstructed from the type alone


### PR DESCRIPTION
This is so that we can write and read things like [Void], or (Expr Void) - something I'm actually doing in Morte.

https://github.com/Gabriel439/Haskell-Morte-Library/pull/26

The reader always fails if you actually try to get an instance of it. Trying to access a void value should not happen for well-formed instances, for example:

    *Data.Binary Data.Void> decode $ encode ([] :: [Void]) :: [Void]
    []