### PR TITLE
Split GBinary into GBinaryGet and GBinaryPut, speeds up compilation.

### DIFF
--- a/src/Data/Binary.hs
+++ b/src/Data/Binary.hs
@@ -30,7 +30,8 @@
 -- If the specifics of the data format is not important to you, for example,
 -- you are more interested in serializing and deserializing values than
 -- in which format will be used, it is possible to derive 'Binary'
--- instances using the generic support. See 'GBinary'.
+-- instances using the generic support. See 'GBinaryGet' and
+-- 'GBinaryPut'.
 --
 -- If you have specific requirements about the encoding format, you can use
 -- the encoding and decoding primitives directly, see the modules
@@ -48,7 +49,8 @@ module Data.Binary (
 #ifdef GENERICS
     -- * Generic support
     -- $generics
-    , GBinary(..)
+    , GBinaryGet(..)
+    , GBinaryPut(..)
 #endif
 
     -- * The Get and Put monads

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -36,7 +36,8 @@ module Data.Binary.Class (
 
 #ifdef GENERICS
     -- * Support for generics
-    , GBinary(..)
+    , GBinaryGet(..)
+    , GBinaryPut(..)
 #endif
 
     ) where
@@ -98,8 +99,14 @@ import Data.Version (Version(..))
 ------------------------------------------------------------------------
 
 #ifdef GENERICS
-class GBinary f where
+-- Factored into two classes because this makes GHC optimize the
+-- instances faster.  This doesn't matter for builds of binary,
+-- but it matters a lot for end-users who write 'instance Binary T'.
+-- See also: https://ghc.haskell.org/trac/ghc/ticket/9630
+class GBinaryPut f where
     gput :: f t -> Put
+
+class GBinaryGet f where
     gget :: Get (f t)
 #endif
 
@@ -127,10 +134,10 @@ class Binary t where
     get :: Get t
 
 #ifdef GENERICS
-    default put :: (Generic t, GBinary (Rep t)) => t -> Put
+    default put :: (Generic t, GBinaryPut (Rep t)) => t -> Put
     put = gput . from
 
-    default get :: (Generic t, GBinary (Rep t)) => Get t
+    default get :: (Generic t, GBinaryGet (Rep t)) => Get t
     get = to `fmap` gget
 #endif
 


### PR DESCRIPTION
Consider:

    {-# LANGUAGE DeriveGeneric #-}
    module A where
    import Data.Binary
    import GHC.Generics
    data T = T
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     () () () () () () () () () ()
     deriving Generic
    instance Binary T

Without this patch, on GHC 7.10.2, building this -O2 takes 6.7s.  With
this patch, it takes 1.7s.  Amazing.  (There are modest improvements
with other versions of GHC too.)

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>