### PR TITLE
Define MonadFail instance for Get Monad

### DIFF
--- a/binary.cabal
+++ b/binary.cabal
@@ -53,8 +53,8 @@ library
 
   ghc-options:     -O2 -Wall -fliberate-case-threshold=1000
 
-  if impl(ghc >= 7.11)
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
 
 -- Due to circular dependency, we cannot make any of the test-suites or
 -- benchmark depend on the binary library. Instead, for each test-suite and

--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -48,6 +48,9 @@ import qualified Data.ByteString.Unsafe as B
 
 import Control.Applicative
 import Control.Monad
+#if MIN_VERSION_base(4,9,0)
+import qualified Control.Monad.Fail as Fail
+#endif
 
 import Data.Binary.Internal ( accursedUnutterablePerformIO )
 
@@ -94,6 +97,11 @@ type Success a r = B.ByteString -> a -> Decoder r
 instance Monad Get where
   return = pure
   (>>=) = bindG
+#if MIN_VERSION_base(4,9,0)
+  fail = Fail.fail
+
+instance Fail.MonadFail Get where
+#endif
   fail = failG
 
 bindG :: Get a -> (a -> Get b) -> Get b


### PR DESCRIPTION
This is the variant not introducing a dependency on http://hackage.haskell.org/package/fail
(see #103 for other variant)