### PR TITLE
Fix build on GHC 7.0 and 7.2

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -60,12 +60,12 @@ import Data.Void
 
 import Data.Binary.Put
 import Data.Binary.Get
+import Data.Binary.Internal ((<>))
 
 #if ! MIN_VERSION_base(4,8,0)
 import Control.Applicative
 import Data.Monoid (mempty)
 #endif
-import Data.Monoid ((<>))
 import Control.Monad
 
 import Data.ByteString.Lazy (ByteString)
@@ -462,7 +462,11 @@ instance (Binary a,Integral a) => Binary (R.Ratio a) where
     put r = put (R.numerator r) <> put (R.denominator r)
     get = liftM2 (R.%) get get
 
-instance Binary a => Binary (Complex a) where
+instance ( Binary a
+#if !(MIN_VERSION_base(4,4,0))
+         , RealFloat a
+#endif
+         ) => Binary (Complex a) where
     {-# INLINE put #-}
     put (r :+ i) = put (r, i)
     {-# INLINE get #-}

--- a/src/Data/Binary/Generic.hs
+++ b/src/Data/Binary/Generic.hs
@@ -25,10 +25,10 @@ module Data.Binary.Generic
 import Control.Applicative
 import Data.Binary.Class
 import Data.Binary.Get
+import Data.Binary.Internal ((<>))
 import Data.Binary.Put
 import Data.Bits
 import Data.Word
-import Data.Monoid ((<>))
 import GHC.Generics
 import Prelude -- Silence AMP warning.
 

--- a/src/Data/Binary/Internal.hs
+++ b/src/Data/Binary/Internal.hs
@@ -1,15 +1,38 @@
 {-# LANGUAGE CPP #-}
 
-module Data.Binary.Internal 
- ( accursedUnutterablePerformIO ) where
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+module Data.Binary.Internal
+ ( accursedUnutterablePerformIO
+ , (<>)
+ ) where
 
 #if MIN_VERSION_bytestring(0,10,6)
 import Data.ByteString.Internal( accursedUnutterablePerformIO )
 #else
 import Data.ByteString.Internal( inlinePerformIO )
+#endif
 
+#if MIN_VERSION_base(4,5,0)
+import Data.Monoid ((<>))
+#else
+import Data.Monoid (Monoid(mappend))
+#endif
+
+#if !(MIN_VERSION_bytestring(0,10,6))
 {-# INLINE accursedUnutterablePerformIO #-}
 -- | You must be truly desperate to come to me for help.
 accursedUnutterablePerformIO :: IO a -> a
 accursedUnutterablePerformIO = inlinePerformIO
+#endif
+
+#if !(MIN_VERSION_base(4,5,0))
+-- Defined for compatibility.
+
+-- | An infix synonym for 'mappend'.
+(<>) :: Monoid m => m -> m -> m
+(<>) = mappend
+{-# INLINE (<>) #-}
 #endif


### PR DESCRIPTION
`binary-0.8.3` fails to build on older GHCs for a couple of reasons:

* `Data.Monoid.<>` was only introduced in `base-4.5` (GHC 7.4). To get around this, I duplicated the definition of `(<>)` in `Data.Binary.Internal`.
* In `base-4.3` (GHC 7.0), the `Complex` datatype has `RealFloat` as a `DatatypeContext`, which forces its `Binary` instance to have a `RealFloat` constraint.

cc @hvr, we should edit the Hackage metadata for `binary-0.8.3` to have `base >= 4.5`