### PR TITLE
[RFC] Get: Avoid needless copies of input

### DIFF
--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -404,7 +404,11 @@ ensureN !n0 = C $ \inp ks -> do
     enoughChunks n str
       | B.length str >= n = Right (str,B.empty)
       | otherwise = Left (n - B.length str)
-    onSucc = B.concat
+    -- Sometimes we will produce leftovers lists of the form [B.empty, nonempty]
+    -- where `nonempty` is a non-empty ByteString. In this case we can avoid a copy
+    -- by simply dropping the empty prefix. In principle ByteString might want
+    -- to gain this optimization as well
+    onSucc = B.concat . dropWhile B.null
     onFail bss = C $ \_ _ -> Fail (B.concat bss) "not enough bytes"
 {-# INLINE ensureN #-}
 


### PR DESCRIPTION
My `b-tree` library seems to tickle a rather pathological behavior in
`binary`'s decoding logic, where `binary` will create many needless
copies of the input buffer by evaluating things of the form `B.concat
[B.empty, leftovers]`, where `leftovers` is large.

This resulted in runtimes of over two minutes when parsing a 50 MByte
file. With this fix run drops to less than 100 milliseconds.