### PR TITLE
Implementation of get/put functions for floats/doubles

### DIFF
--- a/binary.cabal
+++ b/binary.cabal
@@ -108,7 +108,8 @@ benchmark bench
   other-modules: MemBench
   build-depends:
     base >= 4.5.0.0 && < 5,
-    bytestring
+    bytestring,
+    reinterpret-cast
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
   c-sources: benchmarks/CBenchmark.c
@@ -130,7 +131,8 @@ benchmark get
     cereal,
     criterion == 1.*,
     deepseq,
-    mtl
+    mtl,
+    reinterpret-cast
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
   ghc-options: -O2 -Wall
@@ -147,7 +149,8 @@ benchmark put
     base >= 4.5.0.0 && < 5,
     bytestring,
     criterion == 1.*,
-    deepseq
+    deepseq,
+    reinterpret-cast
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
   ghc-options: -O2 -Wall
@@ -169,7 +172,9 @@ benchmark generics-bench
     tar,
     unordered-containers,
     zlib,
-    criterion
+    criterion,
+    reinterpret-cast
+    
   other-modules:
     GenericsBenchCache
     GenericsBenchTypes

--- a/binary.cabal
+++ b/binary.cabal
@@ -31,7 +31,7 @@ source-repository head
   location: git://github.com/kolmodin/binary.git
 
 library
-  build-depends:   base >= 4.5.0.0 && < 5, bytestring >= 0.10.2, containers, array
+  build-depends:   base >= 4.5.0.0 && < 5, bytestring >= 0.10.2, containers, array, reinterpret-cast
   hs-source-dirs:  src
   exposed-modules: Data.Binary,
                    Data.Binary.Put,
@@ -69,7 +69,8 @@ test-suite qc
     random>=1.0.1.0,
     test-framework,
     test-framework-quickcheck2 >= 0.3,
-    QuickCheck>=2.8
+    QuickCheck>=2.8,
+    reinterpret-cast
 
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
@@ -89,7 +90,8 @@ test-suite read-write-file
     Cabal,
     directory,
     filepath,
-    HUnit
+    HUnit,
+    reinterpret-cast
 
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers

--- a/binary.cabal
+++ b/binary.cabal
@@ -31,7 +31,7 @@ source-repository head
   location: git://github.com/kolmodin/binary.git
 
 library
-  build-depends:   base >= 4.5.0.0 && < 5, bytestring >= 0.10.2, containers, array, reinterpret-cast
+  build-depends:   base >= 4.5.0.0 && < 5, bytestring >= 0.10.2, containers, array
   hs-source-dirs:  src
   exposed-modules: Data.Binary,
                    Data.Binary.Put,
@@ -41,7 +41,8 @@ library
 
   other-modules:   Data.Binary.Class,
                    Data.Binary.Internal,
-                   Data.Binary.Generic
+                   Data.Binary.Generic,
+                   Data.Binary.FloatCast
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
@@ -69,8 +70,7 @@ test-suite qc
     random>=1.0.1.0,
     test-framework,
     test-framework-quickcheck2 >= 0.3,
-    QuickCheck>=2.8,
-    reinterpret-cast
+    QuickCheck>=2.8
 
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
@@ -90,8 +90,7 @@ test-suite read-write-file
     Cabal,
     directory,
     filepath,
-    HUnit,
-    reinterpret-cast
+    HUnit
 
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
@@ -108,8 +107,7 @@ benchmark bench
   other-modules: MemBench
   build-depends:
     base >= 4.5.0.0 && < 5,
-    bytestring,
-    reinterpret-cast
+    bytestring
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
   c-sources: benchmarks/CBenchmark.c
@@ -131,8 +129,7 @@ benchmark get
     cereal,
     criterion == 1.*,
     deepseq,
-    mtl,
-    reinterpret-cast
+    mtl
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
   ghc-options: -O2 -Wall
@@ -149,8 +146,7 @@ benchmark put
     base >= 4.5.0.0 && < 5,
     bytestring,
     criterion == 1.*,
-    deepseq,
-    reinterpret-cast
+    deepseq
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
   ghc-options: -O2 -Wall
@@ -172,8 +168,7 @@ benchmark generics-bench
     tar,
     unordered-containers,
     zlib,
-    criterion,
-    reinterpret-cast
+    criterion
     
   other-modules:
     GenericsBenchCache

--- a/src/Data/Binary/FloatCast.hs
+++ b/src/Data/Binary/FloatCast.hs
@@ -1,0 +1,54 @@
+
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | This module is a literal copy of
+--   <http://hackage.haskell.org/package/reinterpret-cast-0.1.0/docs/src/Data-ReinterpretCast-Internal-ImplArray.html>.
+--
+--   Implements casting via a 1-elemnt STUArray, as described in
+--   <http://stackoverflow.com/a/7002812/263061>.
+module Data.Binary.FloatCast
+  ( floatToWord
+  , wordToFloat
+  , doubleToWord
+  , wordToDouble
+  ) where
+
+
+import Data.Word (Word32, Word64)
+import Data.Array.ST (newArray, readArray, MArray, STUArray)
+import Data.Array.Unsafe (castSTUArray)
+import GHC.ST (runST, ST)
+
+
+-- | Reinterpret-casts a `Float` to a `Word32`.
+floatToWord :: Float -> Word32
+floatToWord x = runST (cast x)
+
+{-# INLINEABLE floatToWord #-}
+
+
+-- | Reinterpret-casts a `Word32` to a `Float`.
+wordToFloat :: Word32 -> Float
+wordToFloat x = runST (cast x)
+
+{-# INLINEABLE wordToFloat #-}
+
+
+-- | Reinterpret-casts a `Double` to a `Word64`.
+doubleToWord :: Double -> Word64
+doubleToWord x = runST (cast x)
+
+{-# INLINEABLE doubleToWord #-}
+
+
+-- | Reinterpret-casts a `Word64` to a `Double`.
+wordToDouble :: Word64 -> Double
+wordToDouble x = runST (cast x)
+
+{-# INLINEABLE wordToDouble #-}
+
+
+{-# INLINE cast #-}
+cast :: (MArray (STUArray s) a (ST s),
+         MArray (STUArray s) b (ST s)) => a -> ST s b
+cast x = newArray (0 :: Int, 0) x >>= castSTUArray >>= flip readArray 0

--- a/src/Data/Binary/FloatCast.hs
+++ b/src/Data/Binary/FloatCast.hs
@@ -24,28 +24,28 @@ import GHC.ST (runST, ST)
 floatToWord :: Float -> Word32
 floatToWord x = runST (cast x)
 
-{-# INLINEABLE floatToWord #-}
+{-# INLINE floatToWord #-}
 
 
 -- | Reinterpret-casts a `Word32` to a `Float`.
 wordToFloat :: Word32 -> Float
 wordToFloat x = runST (cast x)
 
-{-# INLINEABLE wordToFloat #-}
+{-# INLINE wordToFloat #-}
 
 
 -- | Reinterpret-casts a `Double` to a `Word64`.
 doubleToWord :: Double -> Word64
 doubleToWord x = runST (cast x)
 
-{-# INLINEABLE doubleToWord #-}
+{-# INLINE doubleToWord #-}
 
 
 -- | Reinterpret-casts a `Word64` to a `Double`.
 wordToDouble :: Word64 -> Double
 wordToDouble x = runST (cast x)
 
-{-# INLINEABLE wordToDouble #-}
+{-# INLINE wordToDouble #-}
 
 
 {-# INLINE cast #-}

--- a/src/Data/Binary/FloatCast.hs
+++ b/src/Data/Binary/FloatCast.hs
@@ -1,5 +1,6 @@
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE Trustworthy #-}
 
 -- | This module was written based on
 --   <http://hackage.haskell.org/package/reinterpret-cast-0.1.0/docs/src/Data-ReinterpretCast-Internal-ImplArray.html>.

--- a/src/Data/Binary/FloatCast.hs
+++ b/src/Data/Binary/FloatCast.hs
@@ -1,7 +1,7 @@
 
 {-# LANGUAGE FlexibleContexts #-}
 
--- | This module is a literal copy of
+-- | This module was written based on
 --   <http://hackage.haskell.org/package/reinterpret-cast-0.1.0/docs/src/Data-ReinterpretCast-Internal-ImplArray.html>.
 --
 --   Implements casting via a 1-elemnt STUArray, as described in
@@ -13,42 +13,32 @@ module Data.Binary.FloatCast
   , wordToDouble
   ) where
 
-
 import Data.Word (Word32, Word64)
 import Data.Array.ST (newArray, readArray, MArray, STUArray)
 import Data.Array.Unsafe (castSTUArray)
 import GHC.ST (runST, ST)
 
-
 -- | Reinterpret-casts a `Float` to a `Word32`.
 floatToWord :: Float -> Word32
 floatToWord x = runST (cast x)
-
 {-# INLINE floatToWord #-}
-
 
 -- | Reinterpret-casts a `Word32` to a `Float`.
 wordToFloat :: Word32 -> Float
 wordToFloat x = runST (cast x)
-
 {-# INLINE wordToFloat #-}
-
 
 -- | Reinterpret-casts a `Double` to a `Word64`.
 doubleToWord :: Double -> Word64
 doubleToWord x = runST (cast x)
-
 {-# INLINE doubleToWord #-}
-
 
 -- | Reinterpret-casts a `Word64` to a `Double`.
 wordToDouble :: Word64 -> Double
 wordToDouble x = runST (cast x)
-
 {-# INLINE wordToDouble #-}
 
-
-{-# INLINE cast #-}
 cast :: (MArray (STUArray s) a (ST s),
          MArray (STUArray s) b (ST s)) => a -> ST s b
 cast x = newArray (0 :: Int, 0) x >>= castSTUArray >>= flip readArray 0
+{-# INLINE cast #-}

--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -238,7 +238,7 @@ import GHC.Word
 #endif
 
 -- needed for casting words to float/double
-import Data.ReinterpretCast (wordToFloat, wordToDouble)
+import Data.Binary.FloatCast (wordToFloat, wordToDouble)
 
 -- $lazyinterface
 -- The lazy interface consumes a single lazy 'L.ByteString'. It's the easiest

--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -205,6 +205,14 @@ module Data.Binary.Get (
     , getInt32host
     , getInt64host
 
+    -- ** Decoding Floats/Doubles
+    , getFloatbe
+    , getFloatle
+    , getFloathost
+    , getDoublebe
+    , getDoublele
+    , getDoublehost
+
     -- * Deprecated functions
     , runGetState -- DEPRECATED
     , remaining -- DEPRECATED
@@ -228,6 +236,9 @@ import qualified Data.Binary.Get.Internal as I
 import GHC.Base
 import GHC.Word
 #endif
+
+-- needed for casting words to float/double
+import Data.ReinterpretCast (wordToFloat, wordToDouble)
 
 -- $lazyinterface
 -- The lazy interface consumes a single lazy 'L.ByteString'. It's the easiest
@@ -607,6 +618,39 @@ getInt64host   :: Get Int64
 getInt64host = getPtr  (sizeOf (undefined :: Int64))
 {-# INLINE getInt64host #-}
 
+
+------------------------------------------------------------------------
+-- Double/Float reads
+
+-- | Read a 'Float' in big endian format.
+getFloatbe :: Get Float
+getFloatbe = wordToFloat <$> getWord32be
+{-# INLINE getFloatbe #-}
+
+-- | Read a 'Float' in little endian format.
+getFloatle :: Get Float
+getFloatle = wordToFloat <$> getWord32le
+{-# INLINE getFloatle #-}
+
+-- | Read a 'Float' in native host order and host endianess.
+getFloathost :: Get Float
+getFloathost = wordToFloat <$> getWord32host
+{-# INLINE getFloathost #-}
+
+-- | Read a 'Double' in big endian format.
+getDoublebe :: Get Double
+getDoublebe = wordToDouble <$> getWord64be
+{-# INLINE getDoublebe #-}
+
+-- | Read a 'Double' in little endian format.
+getDoublele :: Get Double
+getDoublele = wordToDouble <$> getWord64le
+{-# INLINE getDoublele #-}
+
+-- | Read a 'Double' in native host order and host endianess.
+getDoublehost :: Get Double
+getDoublehost = wordToDouble <$> getWord64host
+{-# INLINE getDoublehost #-}
 
 ------------------------------------------------------------------------
 -- Unchecked shifts

--- a/src/Data/Binary/Put.hs
+++ b/src/Data/Binary/Put.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
--- {-# LANGUAGE Safe #-}
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 
 #if MIN_VERSION_base(4,9,0)
 #define HAS_SEMIGROUP

--- a/src/Data/Binary/Put.hs
+++ b/src/Data/Binary/Put.hs
@@ -101,7 +101,7 @@ import Control.Applicative
 import Prelude -- Silence AMP warning.
 
 -- needed for casting Floats/Doubles to words.
-import Data.ReinterpretCast (floatToWord, doubleToWord)
+import Data.Binary.FloatCast (floatToWord, doubleToWord)
 
 ------------------------------------------------------------------------
 

--- a/src/Data/Binary/Put.hs
+++ b/src/Data/Binary/Put.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE Safe #-}
+-- {-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 
 #if MIN_VERSION_base(4,9,0)
 #define HAS_SEMIGROUP
@@ -49,6 +50,8 @@ module Data.Binary.Put (
     , putInt16be
     , putInt32be
     , putInt64be
+    , putFloatbe
+    , putDoublebe
 
     -- * Little-endian primitives
     , putWord16le
@@ -57,6 +60,8 @@ module Data.Binary.Put (
     , putInt16le
     , putInt32le
     , putInt64le
+    , putFloatle
+    , putDoublele
 
     -- * Host-endian, unaligned writes
     , putWordhost           -- :: Word   -> Put
@@ -67,6 +72,8 @@ module Data.Binary.Put (
     , putInt16host          -- :: Int16  -> Put
     , putInt32host          -- :: Int32  -> Put
     , putInt64host          -- :: Int64  -> Put
+    , putFloathost
+    , putDoublehost
 
     -- * Unicode
     , putCharUtf8
@@ -93,6 +100,8 @@ import Data.Semigroup
 import Control.Applicative
 import Prelude -- Silence AMP warning.
 
+-- needed for casting Floats/Doubles to words.
+import Data.ReinterpretCast (floatToWord, doubleToWord)
 
 ------------------------------------------------------------------------
 
@@ -346,6 +355,38 @@ putInt64host       :: Int64 -> Put
 putInt64host       = tell . B.putInt64host
 {-# INLINE putInt64host #-}
 
+------------------------------------------------------------------------
+-- Floats/Doubles
+
+-- | Write a 'Float' in big endian format.
+putFloatbe :: Float -> Put
+putFloatbe = putWord32be . floatToWord
+{-# INLINE putFloatbe #-}
+
+-- | Write a 'Float' in little endian format.
+putFloatle :: Float -> Put
+putFloatle = putWord32le . floatToWord
+{-# INLINE putFloatle #-}
+
+-- | Write a 'Float' in native host order and host endianness.
+putFloathost :: Float -> Put
+putFloathost = putWord32host . floatToWord
+{-# INLINE putFloathost #-}
+
+-- | Write a 'Double' in big endian format.
+putDoublebe :: Double -> Put
+putDoublebe = putWord64be . doubleToWord
+{-# INLINE putDoublebe #-}
+
+-- | Write a 'Double' in little endian format.
+putDoublele :: Double -> Put
+putDoublele = putWord64le . doubleToWord
+{-# INLINE putDoublele #-}
+
+-- | Write a 'Double' in native host order and host endianness.
+putDoublehost :: Double -> Put
+putDoublehost = putWord64host . doubleToWord
+{-# INLINE putDoublehost #-}
 
 ------------------------------------------------------------------------
 -- Unicode

--- a/tests/QC.hs
+++ b/tests/QC.hs
@@ -131,6 +131,26 @@ prop_Int64host = roundTripWith putInt64host getInt64host
 prop_Inthost :: Int -> Property
 prop_Inthost = roundTripWith putInthost getInthost
 
+-- Floats and Doubles
+
+prop_Floatbe :: Float -> Property
+prop_Floatbe = roundTripWith putFloatbe getFloatbe
+
+prop_Floatle :: Float -> Property
+prop_Floatle = roundTripWith putFloatle getFloatle
+
+prop_Floathost :: Float -> Property
+prop_Floathost = roundTripWith putFloathost getFloathost
+
+prop_Doublebe :: Double -> Property
+prop_Doublebe = roundTripWith putDoublebe getDoublebe
+
+prop_Doublele :: Double -> Property
+prop_Doublele = roundTripWith putDoublele getDoublele
+
+prop_Doublehost :: Double -> Property
+prop_Doublehost = roundTripWith putDoublehost getDoublehost
+
 
 -- done, partial and fail
 
@@ -552,6 +572,13 @@ tests =
             , testProperty "Int64le"    (p prop_Int64le)
             , testProperty "Int64host"  (p prop_Int64host)
             , testProperty "Inthost"    (p prop_Inthost)
+              -- Float/Double
+            , testProperty "Floatbe"    (p prop_Floatbe)
+            , testProperty "Floatle"    (p prop_Floatle)
+            , testProperty "Floathost"  (p prop_Floathost)
+            , testProperty "Doublebe"   (p prop_Doublebe)
+            , testProperty "Doublele"   (p prop_Doublele)
+            , testProperty "Doublehost" (p prop_Doublehost)
             ]
 
         , testGroup "String utils"


### PR DESCRIPTION
This PR introduces get/put functions for floats and doubles. It also includes round trip tests for these functions.

You will notice that I added a new dependency: `reinterpret-cast`. This is for fast and convenient cast between words and floating point numbers.

The package `reinterpret-cast` only depends on `array` and `base`, packages `binary` already depend on. If this is a problem, we can have our own implementation, but I think it is better to depend on `reinterpret-cast`. If anybody knows a better way to cast numbers, it can be implemented in `reinterpret-cast`. Then `binary` will be passively improved, and so will be a greater set of packages. If some day `base` includes a function to cast words to/from floating point numbers (efficiently), we can drop the dependency on `reinterpret-cast`.

Note also that the flag `Safe` in `Data.Binary.Put` has been changed to `Trustworthy`. This is because `Data.ReinterpretCast` is not being inferred as safe. I opened nh2/reinterpret-cast#3 regarding this.