### PR TITLE
[travis-ci] Fix build breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ sudo: false
 
 matrix:
   include:
-    - env: CABALVER=1.22 GHCVER=7.4.2
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.6.3
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.6.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.8.4
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
@@ -31,8 +31,10 @@ install:
 # workaround for https://ghc.haskell.org/trac/ghc/ticket/9221
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
  - cabal sandbox init
-# can't use "cabal install --only-dependencies --enable-tests --enable-benchmarks" due to dep-cycle
- - cabal install "bytestring >= 0.10.2" criterion deepseq mtl "QuickCheck >= 2.8" HUnit "test-framework-quickcheck2 >= 0.3" "random >= 1.0.1.0" attoparsec cereal 'Cabal == 1.24.*' tar zlib -j
+# can't use "cabal install --only-dependencies --enable-tests --enable-benchmarks" due to dep-cycle.
+# must split in two separate 'cabal install's since cabal doesn't update the cabal library before it's needed in 'cabal-version' constraints.
+ - cabal install "bytestring >= 0.10.2" 'Cabal == 1.24.*' -j
+ - cabal install criterion deepseq mtl "QuickCheck >= 2.8" HUnit "test-framework-quickcheck2 >= 0.3" "random >= 1.0.1.0" attoparsec cereal tar zlib -j
 
 script:
  - cabal configure --enable-tests --enable-benchmarks -v2 --ghc-options=-fno-spec-constr

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ sudo: false
 matrix:
   include:
     - env: CABALVER=1.18 GHCVER=7.4.2
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.4.2], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.6.3
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ sudo: false
 
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.4.2
+    - env: CABALVER=1.22 GHCVER=7.4.2
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3
+    - env: CABALVER=1.22 GHCVER=7.6.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.6.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4
+    - env: CABALVER=1.22 GHCVER=7.8.4
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}


### PR DESCRIPTION
Seems that older version of cabal-install doesn't correctly handle the constraint "cabal-version".
Attempting to fix the problem by bumping the cabal-install version.