### PR TITLE
Remove redundant pattern-match warning when built with GHC 8.2

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -911,7 +911,6 @@ instance Binary KindRep where
     put (KindRepFun a b) = putWord8 3 >> put a >> put b
     put (KindRepTYPE r) = putWord8 4 >> put r
     put (KindRepTypeLit sort r) = putWord8 5 >> put sort >> put r
-    put _ = fail "GHCi.TH.Binary.putKindRep: Impossible"
 
     get = do
         tag <- getWord8


### PR DESCRIPTION
With the changes in https://phabricator.haskell.org/D3257, GHC HEAD will emit a warning about the `put` definition on `KindRep`s, as it will now correctly bring in `KindRep`'s `COMPLETE` set of patterns into scope and detect that the wildcard pattern is redundant (see [here](https://phabricator.haskell.org/harbormaster/build/22348/) for an example where the build failed because of this). This removes the wildcard pattern to make GHC HEAD build again with `-Werror`.