### PR TITLE
'Binary (NonEmpty a)' should 'fail' on empty lists

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -830,7 +830,11 @@ instance (Binary a, Binary b) => Binary (Semigroup.Arg a b) where
 
 -- | /Since: 0.8.4.0/
 instance Binary a => Binary (NE.NonEmpty a) where
-  get = fmap NE.fromList get
+  get = do
+      list <- get
+      case list of
+        [] -> fail "NonEmpty is actually empty!"
+        x:xs -> pure (x NE.:| xs)
   put = put . NE.toList
 #endif
 

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -833,7 +833,7 @@ instance Binary a => Binary (NE.NonEmpty a) where
   get = do
       list <- get
       case list of
-        [] -> fail "NonEmpty is actually empty!"
+        [] -> fail "NonEmpty is empty!"
         x:xs -> pure (x NE.:| xs)
   put = put . NE.toList
 #endif


### PR DESCRIPTION
Brought up [here](https://cardano.org/wp-content/uploads/2018/08/report.pdf#%5B%7B%22num%22%3A12%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C62.692913386%2C597.699302373%2C0%5D).

Existing behaviour:

```haskell
ghci> runGetOrFail (get :: Get (NonEmpty Word)) (encode ([]:: [Word]))
Right ("",8,*** Exception: NonEmpty.fromList: empty list
```

New behaviour:

```haskell
ghci> runGetOrFail (get :: Get (NonEmpty Word)) (encode ([]:: [Word]))
Left ("",8,"NonEmpty is empty!")
```

