### PR TITLE
Remove unused imports.

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -59,7 +59,9 @@ import Control.Applicative
 import Data.Monoid (mempty)
 #endif
 import qualified Data.Monoid as Monoid
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
+#endif
 #if MIN_VERSION_base(4,8,0)
 import Data.Functor.Identity (Identity (..))
 #endif

--- a/src/Data/Binary/Generic.hs
+++ b/src/Data/Binary/Generic.hs
@@ -30,7 +30,9 @@ import Data.Binary.Get
 import Data.Binary.Put
 import Data.Bits
 import Data.Word
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
+#endif
 #ifdef HAS_DATA_KIND
 import Data.Kind
 #endif


### PR DESCRIPTION
Due to a bug in ghc, some unused imports do not yield warnings.
This commit will remove such unused imports in preparation for
the ghc bug fix (see https://ghc.haskell.org/trac/ghc/ticket/13064).