### PR TITLE
Remove a redundant catch-all clause

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -978,7 +978,6 @@ putTypeRep (Fun arg res) = do
     put (3 :: Word8)
     putTypeRep arg
     putTypeRep res
-putTypeRep _ = error "GHCi.TH.Binary.putTypeRep: Impossible"
 
 getSomeTypeRep :: Get SomeTypeRep
 getSomeTypeRep = do


### PR DESCRIPTION
The clause will be rendered redundant by [GHC MR 963](https://gitlab.haskell.org/ghc/ghc/merge_requests/963).