### PR TITLE
Make Travis build again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ install:
  - >
    cp binary.cabal binary.cabal.orig \
      && sed -i 's/\(name:\s*binary\)/\1-cabal-is-broken/' binary.cabal \
-     && sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal \
-     && diff binary.cabal.orig binary.cabal \
-     || echo 'no fail'
+     && sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal
+ - diff binary.cabal.orig binary.cabal || true
 
 script:
  - cabal new-build --enable-benchmarks --enable-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ sudo: false
 
 matrix:
   include:
-    - env: CABALVER=2.4 GHCVER=7.4.2
-      addons: {apt: {packages: [cabal-install-2.4,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=2.4 GHCVER=7.6.3
-      addons: {apt: {packages: [cabal-install-2.4,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=2.4 GHCVER=7.8.4
       addons: {apt: {packages: [cabal-install-2.4,ghc-7.8.4], sources: [hvr-ghc]}}
     - env: CABALVER=2.4 GHCVER=7.10.3
@@ -44,7 +40,8 @@ install:
    cp binary.cabal binary.cabal.orig \
      && sed -i 's/\(name:\s*binary\)/\1-cabal-is-broken/' binary.cabal \
      && sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal \
-     && diff binary.cabal.orig binary.cabal
+     && diff binary.cabal.orig binary.cabal \
+     || echo 'no fail'
 
 script:
  - cabal new-build --enable-benchmarks --enable-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,18 @@ before_install:
 
 install:
  - cabal --version
- - travis_retry cabal update
+ - travis_retry cabal new-update
 
  # workaround for https://ghc.haskell.org/trac/ghc/ticket/9221
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
 
  # workaround for that cabal cannot make a build plan for binary's
  # tests and benchmarks.
- - sed -i 's/\(name:\s*binary\)/\1-cabal-is-broken/' binary.cabal
- - sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal
+ - >
+   cp binary.cabal binary.cabal.orig \
+     && sed -i 's/\(name:\s*binary\)/\1-cabal-is-broken/' binary.cabal \
+     && sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal \
+     && diff binary.cabal.orig binary.cabal
 
 script:
  - cabal new-build --enable-benchmarks --enable-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,20 @@ sudo: false
 
 matrix:
   include:
-    - env: CABALVER=1.18 CABALUPGR=1.24.* GHCVER=7.4.2
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 CABALUPGR=1.24.* GHCVER=7.6.3
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 CABALUPGR=1.24.* GHCVER=7.8.4
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 CABALUPGR=1.24.* GHCVER=7.10.3
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.2
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.2.2
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.4.4
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.4.4], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.4.2
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.0.2
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.2.2
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.4.4
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
     - env: CABALVER=2.4 GHCVER=8.6.5
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
@@ -34,34 +34,30 @@ before_install:
 install:
  - cabal --version
  - travis_retry cabal update
-# workaround for https://ghc.haskell.org/trac/ghc/ticket/9221
+
+ # workaround for https://ghc.haskell.org/trac/ghc/ticket/9221
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal sandbox init
-# can't use "cabal install --only-dependencies --enable-tests --enable-benchmarks" due to dep-cycle.
-# must split in two separate 'cabal install's since cabal doesn't update the cabal library before it's needed in 'cabal-version' constraints.
- - cabal install "bytestring >= 0.10.4" -j
- - if [ -n "$CABALUPGR" ]; then
-     cabal install "Cabal == $CABALUPGR" -j;
-   fi
- - cabal install "generic-deriving >= 0.10" criterion deepseq mtl "QuickCheck >= 2.8" HUnit "test-framework-quickcheck2 >= 0.3" "random >= 1.0.1.0" attoparsec cereal tar zlib -j
+
+ # workaround for that cabal cannot make a build plan for binary's
+ # tests and benchmarks.
+ - sed -i 's/\(name:\s*binary\)/\1-cabal-is-broken/' binary.cabal
+ - sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal
 
 script:
- - cabal configure --enable-tests --enable-benchmarks -v2 --ghc-options=-fno-spec-constr
- - cabal build
- - cabal test
+ - cabal new-build --enable-benchmarks --enable-tests
 # "cabal check" disabled due to -O2 warning
 # - cabal check
- - cabal sdist
+ - cabal new-sdist
+# TODO(kolmodin): reenable testing that the library installs
 # check that the generated source-distribution can be built & installed
- - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist/;
-   cabal sandbox init;
-   if [ -f "$SRC_TGZ" ]; then
-      cabal install --force-reinstalls "$SRC_TGZ";
-   else
-      echo "expected '$SRC_TGZ' not found";
-      exit 1;
-   fi
+# - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+#   cd dist-newstyle/sdist/;
+#   if [ -f "$SRC_TGZ" ]; then
+#      cabal new-install --force-reinstalls "$SRC_TGZ";
+#   else
+#      echo "expected '$SRC_TGZ' not found";
+#      exit 1;
+#   fi
 
 notifications:
   email:

--- a/binary.cabal
+++ b/binary.cabal
@@ -26,7 +26,7 @@ category:        Data, Parsing
 stability:       provisional
 build-type:      Simple
 cabal-version:   >= 1.8
-tested-with:     GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC ==8.2.2, GHC == 8.4.4, GHC == 8.6.5
+tested-with:     GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC ==8.2.2, GHC == 8.4.4, GHC == 8.6.5
 extra-source-files:
   README.md changelog.md docs/hcar/binary-Lb.tex tools/derive/*.hs
 

--- a/binary.cabal
+++ b/binary.cabal
@@ -1,3 +1,11 @@
+-- To run tests and binaries you'll need to rename the name of the library
+-- and all the local dependencies on it. If not, cabal is unable to come up
+-- with a build plan.
+--
+-- Try this;
+--   sed -i 's/\(name:\s*binary\)/\1-cabal-is-broken/' binary.cabal
+--   sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal
+
 name:            binary
 version:         0.8.7.0
 license:         BSD3
@@ -52,31 +60,17 @@ library
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
 
--- Due to circular dependency, we cannot make any of the test-suites or
--- benchmark depend on the binary library. Instead, for each test-suite and
--- benchmark, we include the source directory of binary and build-depend on all
--- the dependencies binary has.
-
 test-suite qc
   type:  exitcode-stdio-1.0
-  hs-source-dirs: src tests
+  hs-source-dirs: tests
   main-is: QC.hs
   other-modules:
     Action
     Arbitrary
-  other-modules:
-    Data.Binary
-    Data.Binary.Builder
-    Data.Binary.Class
-    Data.Binary.FloatCast
-    Data.Binary.Generic
-    Data.Binary.Get
-    Data.Binary.Get.Internal
-    Data.Binary.Internal
-    Data.Binary.Put
   build-depends:
     base >= 4.5.0.0 && < 5,
     base-orphans >=0.8.1 && <0.9,
+    binary,
     bytestring >= 0.10.4,
     random>=1.0.1.0,
     test-framework,
@@ -93,20 +87,11 @@ test-suite qc
 
 test-suite read-write-file
   type:  exitcode-stdio-1.0
-  hs-source-dirs: src tests
+  hs-source-dirs: tests
   main-is: File.hs
-  other-modules:
-    Data.Binary
-    Data.Binary.Builder
-    Data.Binary.Class
-    Data.Binary.FloatCast
-    Data.Binary.Generic
-    Data.Binary.Get
-    Data.Binary.Get.Internal
-    Data.Binary.Internal
-    Data.Binary.Put
   build-depends:
     base >= 4.5.0.0 && < 5,
+    binary,
     bytestring >= 0.10.4,
     Cabal,
     directory,
@@ -123,21 +108,13 @@ test-suite read-write-file
 
 benchmark bench
   type: exitcode-stdio-1.0
-  hs-source-dirs: src benchmarks
+  hs-source-dirs: benchmarks
   main-is: Benchmark.hs
   other-modules:
     MemBench
-    Data.Binary
-    Data.Binary.Builder
-    Data.Binary.Class
-    Data.Binary.FloatCast
-    Data.Binary.Generic
-    Data.Binary.Get
-    Data.Binary.Get.Internal
-    Data.Binary.Internal
-    Data.Binary.Put
   build-depends:
     base >= 4.5.0.0 && < 5,
+    binary,
     bytestring >= 0.10.4
   -- build dependencies from using binary source rather than depending on the library
   build-depends: array, containers
@@ -151,21 +128,12 @@ benchmark bench
 
 benchmark get
   type: exitcode-stdio-1.0
-  hs-source-dirs: src benchmarks
+  hs-source-dirs: benchmarks
   main-is: Get.hs
-  other-modules:
-    Data.Binary
-    Data.Binary.Builder
-    Data.Binary.Class
-    Data.Binary.FloatCast
-    Data.Binary.Generic
-    Data.Binary.Get
-    Data.Binary.Get.Internal
-    Data.Binary.Internal
-    Data.Binary.Put
   build-depends:
     attoparsec,
     base >= 4.5.0.0 && < 5,
+    binary,
     bytestring >= 0.10.4,
     cereal,
     criterion == 1.*,
@@ -181,20 +149,11 @@ benchmark get
 
 benchmark put
   type: exitcode-stdio-1.0
-  hs-source-dirs: src benchmarks
+  hs-source-dirs: benchmarks
   main-is: Put.hs
-  other-modules:
-    Data.Binary
-    Data.Binary.Builder
-    Data.Binary.Class
-    Data.Binary.FloatCast
-    Data.Binary.Generic
-    Data.Binary.Get
-    Data.Binary.Get.Internal
-    Data.Binary.Internal
-    Data.Binary.Put
   build-depends:
     base >= 4.5.0.0 && < 5,
+    binary,
     bytestring >= 0.10.4,
     criterion == 1.*,
     deepseq
@@ -207,20 +166,11 @@ benchmark put
 
 benchmark generics-bench
   type: exitcode-stdio-1.0
-  hs-source-dirs: src benchmarks
+  hs-source-dirs: benchmarks
   main-is: GenericsBench.hs
-  other-modules:
-    Data.Binary
-    Data.Binary.Builder
-    Data.Binary.Class
-    Data.Binary.FloatCast
-    Data.Binary.Generic
-    Data.Binary.Get
-    Data.Binary.Get.Internal
-    Data.Binary.Internal
-    Data.Binary.Put
   build-depends:
     base >= 4.5.0.0 && < 5,
+    binary,
     bytestring >= 0.10.4,
     -- The benchmark already depended on 'generic-deriving' transitively. That's
     -- what caused one of the problems, as both 'generic-deriving' and
@@ -245,20 +195,11 @@ benchmark generics-bench
 
 benchmark builder
   type: exitcode-stdio-1.0
-  hs-source-dirs: src benchmarks
+  hs-source-dirs: benchmarks
   main-is: Builder.hs
-  other-modules:
-    Data.Binary
-    Data.Binary.Builder
-    Data.Binary.Class
-    Data.Binary.FloatCast
-    Data.Binary.Generic
-    Data.Binary.Get
-    Data.Binary.Get.Internal
-    Data.Binary.Internal
-    Data.Binary.Put
   build-depends:
     base >= 4.5.0.0 && < 5,
+    binary,
     bytestring >= 0.10.4,
     criterion == 1.*,
     deepseq,

--- a/tests/QC.hs
+++ b/tests/QC.hs
@@ -43,7 +43,6 @@ import           Arbitrary                            ()
 import           Data.Binary
 import           Data.Binary.Get
 import           Data.Binary.Put
-import qualified Data.Binary.Class as Class
 
 
 ------------------------------------------------------------------------
@@ -161,7 +160,7 @@ testTypeable :: Test
 testTypeable = testProperty "TypeRep" prop_TypeRep
 
 prop_TypeRep :: TypeRep -> Property
-prop_TypeRep = roundTripWith Class.put Class.get
+prop_TypeRep = roundTripWith put get
 
 atomicTypeReps :: [TypeRep]
 atomicTypeReps =


### PR DESCRIPTION
Travis keeps breaking due to its very fragile build script.
Switching to an approch which I hope will be more robust.

Only use recent version of cabal when building for all GHC versions.
This means we no longer test older cabal install binaries.

cabal-install is unable to come up with a build plan for the tests and
benchmarks. The problem seems to be that building binary's
tests/benchmarks requires having binary, which is what we're trying to
build. Cabal doesn't seem to separate the lib/tests/benchmarks into
distinct build units, so it fails to come up with a plan.

To work around this, when building on travis, we rename the binary
library. With a new name, cabal can find a plan and run the tests.