### PR TITLE
Remove instance for Data.Semigroup.Option for GHC >= 9.2

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -812,10 +812,12 @@ instance Binary a => Binary (Semigroup.Last a) where
   get = fmap Semigroup.Last get
   put = put . Semigroup.getLast
 
+#if __GLASGOW_HASKELL__ < 901
 -- | @since 0.8.4.0
 instance Binary a => Binary (Semigroup.Option a) where
   get = fmap Semigroup.Option get
   put = put . Semigroup.getOption
+#endif
 
 -- | @since 0.8.4.0
 instance Binary m => Binary (Semigroup.WrappedMonoid m) where


### PR DESCRIPTION
Corresponding GHC MR:
https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4945