### PR TITLE
Changes for GHC 9.2.1

### DIFF
--- a/binary.cabal
+++ b/binary.cabal
@@ -1,3 +1,5 @@
+cabal-version:  3.0
+
 -- To run tests and binaries you'll need to rename the name of the library
 -- and all the local dependencies on it. If not, cabal is unable to come up
 -- with a build plan.
@@ -8,7 +10,7 @@
 
 name:            binary
 version:         0.8.8.0
-license:         BSD3
+license:         BSD-3-Clause
 license-file:    LICENSE
 author:          Lennart Kolmodin <kolmodin@gmail.com>
 maintainer:      Lennart Kolmodin, Don Stewart <dons00@gmail.com>
@@ -25,7 +27,6 @@ synopsis:        Binary serialisation for Haskell values using lazy ByteStrings
 category:        Data, Parsing
 stability:       provisional
 build-type:      Simple
-cabal-version:   >= 1.8
 tested-with:     GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC ==8.2.2, GHC == 8.4.4, GHC == 8.6.5
 extra-source-files:
   README.md changelog.md docs/hcar/binary-Lb.tex tools/derive/*.hs
@@ -59,6 +60,7 @@ library
 
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+  default-language: Haskell2010
 
 test-suite qc
   type:  exitcode-stdio-1.0
@@ -83,6 +85,7 @@ test-suite qc
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
+  default-language: Haskell2010
 
 
 test-suite read-write-file
@@ -104,6 +107,7 @@ test-suite read-write-file
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
+  default-language: Haskell2010
 
 
 benchmark bench
@@ -124,6 +128,7 @@ benchmark bench
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
+  default-language: Haskell2010
 
 
 benchmark get
@@ -145,6 +150,7 @@ benchmark get
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
+  default-language: Haskell2010
 
 
 benchmark put
@@ -163,6 +169,7 @@ benchmark put
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
+  default-language: Haskell2010
 
 benchmark generics-bench
   type: exitcode-stdio-1.0
@@ -192,6 +199,7 @@ benchmark generics-bench
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
+  default-language: Haskell2010
 
 benchmark builder
   type: exitcode-stdio-1.0
@@ -210,3 +218,4 @@ benchmark builder
   if impl(ghc <= 7.6)
     -- prior to ghc-7.4 generics lived in ghc-prim
     build-depends: ghc-prim
+  default-language: Haskell2010

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -110,6 +110,10 @@ import Numeric.Natural
 
 import qualified Data.Fixed as Fixed
 
+#if MIN_VERSION_base(4,14,0)
+import GHC.Exts (Levity(Lifted,Unlifted))
+#endif
+
 --
 -- This isn't available in older Hugs or older GHC
 --
@@ -885,8 +889,13 @@ instance Binary RuntimeRep where
     put (VecRep a b)    = putWord8 0 >> put a >> put b
     put (TupleRep reps) = putWord8 1 >> put reps
     put (SumRep reps)   = putWord8 2 >> put reps
+#if __GLASGOW_HASKELL__ >= 811
+    put (BoxedRep Lifted)   = putWord8 3
+    put (BoxedRep Unlifted) = putWord8 4
+#else
     put LiftedRep       = putWord8 3
     put UnliftedRep     = putWord8 4
+#endif
     put IntRep          = putWord8 5
     put WordRep         = putWord8 6
     put Int64Rep        = putWord8 7
@@ -911,8 +920,13 @@ instance Binary RuntimeRep where
           0  -> VecRep <$> get <*> get
           1  -> TupleRep <$> get
           2  -> SumRep <$> get
+#if __GLASGOW_HASKELL__ >= 811
+          3  -> pure (BoxedRep Lifted)
+          4  -> pure (BoxedRep Unlifted)
+#else
           3  -> pure LiftedRep
           4  -> pure UnliftedRep
+#endif
           5  -> pure IntRep
           6  -> pure WordRep
           7  -> pure Int64Rep

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -110,7 +110,7 @@ import Numeric.Natural
 
 import qualified Data.Fixed as Fixed
 
-#if __GLASGOW_HASKELL__ >= 811
+#if __GLASGOW_HASKELL__ >= 901
 import GHC.Exts (Levity(Lifted,Unlifted))
 #endif
 
@@ -889,7 +889,7 @@ instance Binary RuntimeRep where
     put (VecRep a b)    = putWord8 0 >> put a >> put b
     put (TupleRep reps) = putWord8 1 >> put reps
     put (SumRep reps)   = putWord8 2 >> put reps
-#if __GLASGOW_HASKELL__ >= 811
+#if __GLASGOW_HASKELL__ >= 901
     put (BoxedRep Lifted)   = putWord8 3
     put (BoxedRep Unlifted) = putWord8 4
 #else
@@ -920,7 +920,7 @@ instance Binary RuntimeRep where
           0  -> VecRep <$> get <*> get
           1  -> TupleRep <$> get
           2  -> SumRep <$> get
-#if __GLASGOW_HASKELL__ >= 811
+#if __GLASGOW_HASKELL__ >= 901
           3  -> pure (BoxedRep Lifted)
           4  -> pure (BoxedRep Unlifted)
 #else

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -110,7 +110,7 @@ import Numeric.Natural
 
 import qualified Data.Fixed as Fixed
 
-#if MIN_VERSION_base(4,14,0)
+#if __GLASGOW_HASKELL__ >= 811
 import GHC.Exts (Levity(Lifted,Unlifted))
 #endif
 


### PR DESCRIPTION
* Set `default-language: Haskell2010`, otherwise GHC 9.2 will compile the package as GHC2021, which will break due to a Safe Haskell error. See GHC #19631.
* Add support for BoxedRep.
