### PR TITLE
Bump version to 0.8.9.0

### DIFF
--- a/binary.cabal
+++ b/binary.cabal
@@ -9,7 +9,7 @@ cabal-version:  3.0
 --   sed -i 's/\(binary\),/\1-cabal-is-broken,/' binary.cabal
 
 name:            binary
-version:         0.8.8.0
+version:         0.8.9.0
 license:         BSD-3-Clause
 license-file:    LICENSE
 author:          Lennart Kolmodin <kolmodin@gmail.com>

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 binary
 ======
 
+binary-0.8.9.0
+--------------
+
+- Compatibility with GHC 9.2
+- Drop instances for deprecated `Data.Semigroup.Option`
+
 binary-0.8.8.0
 --------------
 


### PR DESCRIPTION
This is the version that will ship with 9.2.1; it would be appreciated if you could release this as-is.