### PR TITLE
Remove `Option` instance removal from the changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,7 @@ binary
 binary-0.8.9.0
 --------------
 
-- Compatibility with GHC 9.2
-- Drop instances for deprecated `Data.Semigroup.Option`
+- Compatibility with GHC 9.2 and base-4.16
 
 binary-0.8.8.0
 --------------


### PR DESCRIPTION
It sounds like it's removed unconditionally, which would been PVP violation in minor version. Better to not mention it at all, as it's part of compatibility with GHC-9.2 (base-4.16). We cannot define instances for types which don't exist.