### PR TITLE
fix typos

### DIFF
--- a/docker/Dockerfile.anyghc
+++ b/docker/Dockerfile.anyghc
@@ -42,7 +42,7 @@
 #      Thus .travis.yml gets out of sync when we forget.
 #      This method also doesn't work with the nix-style commands which
 #      themselves take care of installing dependencies.
-#      The simples workaround I've found, and the only thing that works
+#      The simplest workaround I've found, and the only thing that works
 #      with nix-style commands, is to simply rename the package
 #
 #   3) Do 'cabal sdist' to get only the files for source distribution.

--- a/docker/Dockerfile.ghc843
+++ b/docker/Dockerfile.ghc843
@@ -38,7 +38,7 @@
 #      Thus .travis.yml gets out of sync when we forget.
 #      This method also doesn't work with the nix-style commands which
 #      themselves take care of installing dependencies.
-#      The simples workaround I've found, and the only thing that works
+#      The simplest workaround I've found, and the only thing that works
 #      with nix-style commands, is to simply rename the package
 #
 #   3) Do 'cabal sdist' to get only the files for source distribution.

--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -257,7 +257,7 @@ import Data.Binary.FloatCast (wordToFloat, wordToDouble)
 -- If it succeeds it will return 'Done' with the resulting value,
 -- the position and the remaining input.
 
--- | A decoder procuced by running a 'Get' monad.
+-- | A decoder produced by running a 'Get' monad.
 data Decoder a = Fail !B.ByteString {-# UNPACK #-} !ByteOffset String
               -- ^ The decoder ran into an error. The decoder either used
               -- 'fail' or was not provided enough input. Contains any

--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -76,7 +76,7 @@ data Decoder a = Fail !B.ByteString String
               -- output value you also get the unused input.
               | BytesRead {-# UNPACK #-} !Int64 (Int64 -> Decoder a)
               -- ^ The decoder needs to know the current position in the input.
-              -- Given the number of bytes remaning in the decoder, the outer
+              -- Given the number of bytes remaining in the decoder, the outer
               -- decoder runner needs to calculate the position and
               -- resume the decoding.
 

--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, RankNTypes, MagicHash, BangPatterns, TypeFamilies #-}
 
--- CPP C style pre-precessing, the #if defined lines
+-- CPP C-style preprocessing, the #if defined lines
 -- RankNTypes forall r. statement
 -- MagicHash the (# unboxing #), also needs GHC.primitives
 
@@ -56,7 +56,7 @@ import Data.Binary.Internal ( accursedUnutterablePerformIO )
 
 -- Kolmodin 20100427: at zurihac we discussed of having partial take a
 -- "Maybe ByteString" and implemented it in this way.
--- The reasoning was that you could accidently provide an empty bytestring,
+-- The reasoning was that you could accidentally provide an empty bytestring,
 -- and it should not terminate the decoding (empty would mean eof).
 -- However, I'd say that it's also a risk that you get stuck in a loop,
 -- where you keep providing an empty string. Anyway, no new input should be

--- a/tests/Action.hs
+++ b/tests/Action.hs
@@ -197,7 +197,7 @@ failReason _ = "NoFail"
 
 -- | The result of an evaluation.
 data Eval = ESuccess Int
-          -- ^ The evalutation completed successfully. Contains the number of
+          -- ^ The evaluation completed successfully. Contains the number of
           -- remaining bytes of the input.
           | EFail FailReason [String] Int
           -- ^ The evaluation completed with a failure. Contains the labels up

--- a/tests/Action.hs
+++ b/tests/Action.hs
@@ -212,7 +212,7 @@ data FailReason
   deriving (Show,Eq)
 
 -- | Given the number of input bytes and a list of actions, evaluate the
--- actions and return whether the actions succeeed or fail.
+-- actions and return whether the actions succeed or fail.
 eval :: Int -> [Action] -> Eval
 eval inp0 = go inp0 []
   where

--- a/tests/QC.hs
+++ b/tests/QC.hs
@@ -265,7 +265,7 @@ prop_bytesRead lbs =
 -- | We're trying to guarantee that the Decoder will not ask for more input
 -- with Partial if it has been given Nothing once.
 -- In this test we're making the decoder return 'Partial' to get more
--- input, and to get knownledge of the current position using 'BytesRead'.
+-- input, and to get knowledge of the current position using 'BytesRead'.
 -- Both of these operations, when used with the <|> operator, result internally
 -- in that the decoder return with Partial and BytesRead multiple times,
 -- in which case we need to keep track of if the user has passed Nothing to a


### PR DESCRIPTION
src/Data/Binary/Get.hs
src/Data/Binary/Get/Internal.hs
tests/Action.hs
tests/QC.hs

my presumption is `produced` and not `procured` was the intention

```
$ grep -nr procuced binary
binary/src/Data/Binary/Get.hs:260:-- | A decoder procuced by running a 'Get' monad.
$ 
```
docker/Dockerfile.anyghc
docker/Dockerfile.ghc843
src/Data/Binary/Get/Internal.hs
tests/Action.hs
