### PR TITLE
Drop efficiency wording

### DIFF
--- a/binary.cabal
+++ b/binary.cabal
@@ -15,14 +15,14 @@ license-file:    LICENSE
 author:          Lennart Kolmodin <kolmodin@gmail.com>
 maintainer:      Lennart Kolmodin, Don Stewart <dons00@gmail.com>
 homepage:        https://github.com/kolmodin/binary
-description:     Efficient, pure binary serialisation using lazy ByteStrings.
+description:     Pure binary serialisation using lazy ByteStrings.
                  Haskell values may be encoded to and from binary formats,
                  written to disk as binary, or sent over the network.
                  The format used can be automatically generated, or
                  you can choose to implement a custom format if needed.
                  Serialisation speeds of over 1 G\/sec have been observed,
-                 so this library should be suitable for high performance
-                 scenarios.
+                 but this library is not suitable for high performance
+                 scenarios, as other options are far faster.
 synopsis:        Binary serialisation for Haskell values using lazy ByteStrings
 category:        Data, Parsing
 stability:       provisional


### PR DESCRIPTION
Given that almost all other binary serialization packages are faster (https://github.com/haskell-perf/serialization/blob/master/report.md), and compared with serialise and store, is 2-6x slower, I’ve never recommended the binary package to anyone for a real performance critical program. I think it’s worth changing the wording on the Hackage description lest people get the wrong impression.

As far as I’m aware, the only reason people use binary is its low dependency footprint, being shipped with/“blessed” by GHC. 