### PR TITLE
Mark many in Alternative instance as INLINEABLE

### DIFF
--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -282,7 +282,7 @@ instance Alternative Get where
     case v of
       Nothing -> pure []
       Just x -> (:) x <$> many p
-  {-# INLINE many #-}
+  {-# INLINEABLE many #-} -- many will never inline because it's recursive, so mark it INLINEABLE instead.
 
 -- | Run a decoder and keep track of all the input it consumes.
 -- Once it's finished, return the final decoder (always 'Done' or 'Fail'),


### PR DESCRIPTION
Since many is recursive ghc will never inline it. Even if we mark as INLINE.
However ghc will complain if we compile with core lint enabled.

So we just mark it as INLINEABLE instead.