### PR TITLE
Added comments for Float and Double instances

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -683,6 +683,7 @@ instance (Binary e) => Binary (Seq.Seq e) where
 ------------------------------------------------------------------------
 -- Floating point
 
+-- | Uses non-IEEE754 encoding. Does not round-trip NaN.
 instance Binary Double where
     put d = put (decodeFloat d)
     get   = do
@@ -690,6 +691,7 @@ instance Binary Double where
         y <- get
         return $! encodeFloat x y
 
+-- | Uses non-IEEE754 encoding. Does not round-trip NaN.
 instance Binary Float where
     put f = put (decodeFloat f)
     get   =  do


### PR DESCRIPTION
This commit partially addresses #69, reducing user surprise by the non-round-tripping behavior of the Float and Double instances.

It is unfortunate that the following Haddock issue pushes typeclass instance documentation to be side notes, but at least the currently-added typeclass documentation is still visible on the resulting Haddock page.
https://github.com/haskell/haddock/issues/300
