### PR TITLE
-Wnoncanonical-monadfail-instances is deprecated: fail is no longer a…

### DIFF
--- a/binary.cabal
+++ b/binary.cabal
@@ -59,7 +59,7 @@ library
   ghc-options:     -O2 -Wall -fliberate-case-threshold=1000
 
   if impl(ghc >= 8.0)
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances
   default-language: Haskell2010
 
 test-suite qc


### PR DESCRIPTION
… method of Monad