### PR TITLE
Add `Binary (Proxy a)` instance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,11 @@
 binary
 ======
 
-binary-0.9.0.0
+binary-x.x.x.x
 --------------
 
 - Don't reexport `Data.Word` from `Data.Binary`
+- Add `Binary (Proxy a)` instance
 
 binary-0.8.9.2
 --------------

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -51,6 +51,7 @@ import Data.Word
 import Data.Bits
 import Data.Int
 import Data.Complex (Complex(..))
+import Data.Proxy (Proxy(..))
 #ifdef HAS_VOID
 import Data.Void
 #endif
@@ -193,6 +194,10 @@ instance Binary Void where
 instance Binary () where
     put ()  = mempty
     get     = return ()
+
+instance Binary (Proxy a) where
+    put Proxy = pure ()
+    get       = pure Proxy
 
 -- Bools are encoded as a byte in the range 0 .. 1
 instance Binary Bool where


### PR DESCRIPTION
Closes #126.

`put` forces its argument, for consistency with the `Binary ()` instance.