### PR TITLE
Add `getShortByteString`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ binary
 binary-x.x.x.x
 --------------
 
+- Add `Data.Binary.Get.getShortByteString`
 - Don't reexport `Data.Word` from `Data.Binary`
 - Add `Binary (Proxy a)` instance
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ binary
 binary-x.x.x.x
 --------------
 
+TODO: fix since annotations
+
 - Add `Data.Binary.Get.getShortByteString`
 - Don't reexport `Data.Word` from `Data.Binary`
 - Add `Binary (Proxy a)` instance

--- a/src/Data/Binary/Builder.hs
+++ b/src/Data/Binary/Builder.hs
@@ -28,9 +28,7 @@ module Data.Binary.Builder (
     , append
     , fromByteString        -- :: S.ByteString -> Builder
     , fromLazyByteString    -- :: L.ByteString -> Builder
-#if MIN_VERSION_bytestring(0,10,4)
     , fromShortByteString   -- :: T.ByteString -> Builder
-#endif
     -- * Flushing the buffer state
     , flush
 
@@ -66,12 +64,9 @@ module Data.Binary.Builder (
     , putStringUtf8
     ) where
 
-import qualified Data.ByteString      as S
-import qualified Data.ByteString.Lazy as L
-
-#if MIN_VERSION_bytestring(0,10,4)
+import qualified Data.ByteString       as S
+import qualified Data.ByteString.Lazy  as L
 import qualified Data.ByteString.Short as T
-#endif
 
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Builder.Extra as B
@@ -127,7 +122,6 @@ fromLazyByteString :: L.ByteString -> Builder
 fromLazyByteString = B.lazyByteString
 {-# INLINE fromLazyByteString #-}
 
-#if MIN_VERSION_bytestring(0,10,4)
 -- | /O(n)./ A builder taking 'T.ShortByteString' and copy it to a Builder,
 -- satisfying
 --
@@ -135,7 +129,6 @@ fromLazyByteString = B.lazyByteString
 fromShortByteString :: T.ShortByteString -> Builder
 fromShortByteString = B.shortByteString
 {-# INLINE fromShortByteString #-}
-#endif
 
 ------------------------------------------------------------------------
 

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -90,9 +90,7 @@ import Data.Kind (Type)
 import GHC.Exts (RuntimeRep(..), VecCount, VecElem)
 #endif
 import qualified Data.ByteString as B
-#if MIN_VERSION_bytestring(0,10,4)
 import qualified Data.ByteString.Short as BS
-#endif
 import qualified Data.Map        as Map
 import qualified Data.Set        as Set
 import qualified Data.IntMap     as IntMap
@@ -643,12 +641,10 @@ instance Binary ByteString where
     get    = get >>= getLazyByteString
 
 
-#if MIN_VERSION_bytestring(0,10,4)
 instance Binary BS.ShortByteString where
    put bs = put (BS.length bs)
             <> putShortByteString bs
-   get = get >>= fmap BS.toShort . getByteString
-#endif
+   get = get >>= getShortByteString
 
 ------------------------------------------------------------------------
 -- Maps and Sets

--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -171,6 +171,7 @@ module Data.Binary.Get (
     , getLazyByteString
     , getLazyByteStringNul
     , getRemainingLazyByteString
+    , getShortByteString
 
     -- ** Decoding Words
     , getWord8
@@ -232,6 +233,7 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Unsafe as B
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Internal as L
+import Data.ByteString.Short (ShortByteString, toShort)
 
 import Data.Binary.Get.Internal hiding ( Decoder(..), runGetIncremental )
 import qualified Data.Binary.Get.Internal as I
@@ -431,6 +433,9 @@ getLazyByteStringNul = withInputChunks () consumeUntilNul L.fromChunks failOnEOF
 -- all input and keeping the string in-memory.
 getRemainingLazyByteString :: Get L.ByteString
 getRemainingLazyByteString = withInputChunks () consumeAll L.fromChunks resumeOnEOF
+
+getShortByteString :: Int -> Get ShortByteString
+getShortByteString = fmap toShort . getByteString
 
 ------------------------------------------------------------------------
 -- Primitives

--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -438,6 +438,8 @@ getRemainingLazyByteString = withInputChunks () consumeAll L.fromChunks resumeOn
 -- | @getShortByteString n@ gets a `ShortByteString` of length @n@.
 -- Fails if fewer than @n@ bytes are left in the input.
 -- If @n <= 0@, the empty string is returned.
+--
+-- @since x.x.x.x
 getShortByteString :: Int -> Get ShortByteString
 getShortByteString = fmap toShort . getByteString
 

--- a/src/Data/Binary/Get.hs
+++ b/src/Data/Binary/Get.hs
@@ -400,8 +400,9 @@ pushEndOfInput r =
 skip :: Int -> Get ()
 skip n = withInputChunks (fromIntegral n) consumeBytes (const ()) failOnEOF
 
--- | An efficient get method for lazy ByteStrings. Fails if fewer than @n@
--- bytes are left in the input.
+-- | @getLazyByteString n@ efficiently gets a lazy `Data.ByteString.Lazy.ByteString` of length @n@.
+-- Fails if fewer than @n@ bytes are left in the input.
+-- If @n <= 0@, the empty string is returned.
 getLazyByteString :: Int64 -> Get L.ByteString
 getLazyByteString n0 = withInputChunks n0 consumeBytes L.fromChunks failOnEOF
 
@@ -434,6 +435,9 @@ getLazyByteStringNul = withInputChunks () consumeUntilNul L.fromChunks failOnEOF
 getRemainingLazyByteString :: Get L.ByteString
 getRemainingLazyByteString = withInputChunks () consumeAll L.fromChunks resumeOnEOF
 
+-- | @getShortByteString n@ gets a `ShortByteString` of length @n@.
+-- Fails if fewer than @n@ bytes are left in the input.
+-- If @n <= 0@, the empty string is returned.
 getShortByteString :: Int -> Get ShortByteString
 getShortByteString = fmap toShort . getByteString
 

--- a/src/Data/Binary/Get/Internal.hs
+++ b/src/Data/Binary/Get/Internal.hs
@@ -378,8 +378,9 @@ remaining = C $ \ inp ks ->
 -- ByteStrings
 --
 
--- | An efficient get method for strict ByteStrings. Fails if fewer than @n@
--- bytes are left in the input. If @n <= 0@ then the empty string is returned.
+-- | @getLazyByteString n@ efficiently gets a strict `Data.ByteString.ByteString` of length @n@.
+-- Fails if fewer than @n@ bytes are left in the input.
+-- If @n <= 0@, the empty string is returned.
 getByteString :: Int -> Get B.ByteString
 getByteString n | n > 0 = readN n (B.unsafeTake n)
                 | otherwise = return B.empty

--- a/src/Data/Binary/Put.hs
+++ b/src/Data/Binary/Put.hs
@@ -38,9 +38,7 @@ module Data.Binary.Put (
     , putInt8
     , putByteString
     , putLazyByteString
-#if MIN_VERSION_bytestring(0,10,4)
     , putShortByteString
-#endif
 
     -- * Big-endian primitives
     , putWord16be
@@ -88,9 +86,7 @@ import Data.Int
 import Data.Word
 import qualified Data.ByteString      as S
 import qualified Data.ByteString.Lazy as L
-#if MIN_VERSION_bytestring(0,10,4)
 import Data.ByteString.Short
-#endif
 
 #ifdef HAS_SEMIGROUP
 import Data.Semigroup
@@ -226,12 +222,10 @@ putLazyByteString   :: L.ByteString -> Put
 putLazyByteString   = tell . B.fromLazyByteString
 {-# INLINE putLazyByteString #-}
 
-#if MIN_VERSION_bytestring(0,10,4)
 -- | Write 'ShortByteString' to the buffer
 putShortByteString :: ShortByteString -> Put
 putShortByteString = tell . B.fromShortByteString
 {-# INLINE putShortByteString #-}
-#endif
 
 -- | Write a Word16 in big endian format
 putWord16be         :: Word16 -> Put

--- a/tests/Arbitrary.hs
+++ b/tests/Arbitrary.hs
@@ -7,9 +7,7 @@ import Test.QuickCheck
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
-#if MIN_VERSION_bytestring(0,10,4)
 import qualified Data.ByteString.Short as S
-#endif
 
 instance Arbitrary L.ByteString where
   arbitrary = fmap L.fromChunks arbitrary
@@ -17,7 +15,5 @@ instance Arbitrary L.ByteString where
 instance Arbitrary B.ByteString where
   arbitrary = B.pack `fmap` arbitrary
 
-#if MIN_VERSION_bytestring(0,10,4)
 instance Arbitrary S.ShortByteString where
   arbitrary = S.toShort `fmap` arbitrary
-#endif

--- a/tests/QC.hs
+++ b/tests/QC.hs
@@ -16,9 +16,7 @@ import           Control.Monad                        (unless, liftM2)
 import qualified Data.ByteString                      as B
 import qualified Data.ByteString.Lazy                 as L
 import qualified Data.ByteString.Lazy.Internal        as L
-#if MIN_VERSION_bytestring(0,10,4)
 import           Data.ByteString.Short                (ShortByteString)
-#endif
 import           Data.Int
 import           Data.Ratio
 import           Data.Typeable
@@ -716,9 +714,7 @@ tests =
 
             , test' "B.ByteString" (test :: T B.ByteString) test
             , test' "L.ByteString" (test :: T L.ByteString) test
-#if MIN_VERSION_bytestring(0,10,4)
             , test' "ShortByteString" (test :: T ShortByteString) test
-#endif
             ]
 
         , testGroup "Invariants" $ map (uncurry testProperty)
@@ -726,10 +722,8 @@ tests =
             , ("[B.ByteString] invariant", p (prop_invariant :: B [B.ByteString]               ))
             , ("L.ByteString invariant",   p (prop_invariant :: B L.ByteString                 ))
             , ("[L.ByteString] invariant", p (prop_invariant :: B [L.ByteString]               ))
-#if MIN_VERSION_bytestring(0,10,4)
             , ("ShortByteString invariant",  p (prop_invariant :: B ShortByteString            ))
             , ("[ShortByteString] invariant", p (prop_invariant :: B [ShortByteString]         ))
-#endif
             ]
 #ifdef HAS_FIXED_CONSTRUCTOR
         , testGroup "Fixed"


### PR DESCRIPTION
Closes https://github.com/haskell/binary/issues/211.

`ShortByteString` already had a `Binary` instance, so I just copied the implementation from there. Also drop the `#if MIN_VERSION_bytestring(0,10,4)` CPP, since we require `bytestring >= 0.10.4` anyway.