### PR TITLE
Fail on zero denominator in `Binary (Ratio a)` instance

### DIFF
--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -491,7 +491,10 @@ freezeByteArray arr = IO $ \s ->
 
 instance (Binary a,Integral a) => Binary (R.Ratio a) where
     put r = put (R.numerator r) <> put (R.denominator r)
-    get = liftM2 (R.%) get get
+    get = do
+        n <- get
+        d <- get
+        if d == 0 then fail "zero denominator" else pure (n R.% d)
 
 instance Binary a => Binary (Complex a) where
     {-# INLINE put #-}


### PR DESCRIPTION
Fail on zero denominator in `Binary (Ratio a)` instance, instead of throwing an exception.