### PR TITLE
Use IEEE754 encoding for `Float` and `Double` instances

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ binary-x.x.x.x
 
 TODO: fix since annotations
 
+- Change `Binary` instances for `Float` and `Double` to use IEEE754 encoding.
 - Add `Data.Binary.Get.getShortByteString`
 - Don't reexport `Data.Word` from `Data.Binary`
 - Add `Binary (Proxy a)` instance

--- a/src/Data/Binary/Class.hs
+++ b/src/Data/Binary/Class.hs
@@ -744,21 +744,15 @@ instance (Binary e) => Binary (Seq.Seq e) where
 ------------------------------------------------------------------------
 -- Floating point
 
--- | Uses non-IEEE754 encoding. Does not round-trip NaN.
+-- | Uses IEEE754 encoding.
 instance Binary Double where
-    put d = put (decodeFloat d)
-    get   = do
-        x <- get
-        y <- get
-        return $! encodeFloat x y
+    put = putDoublebe
+    get = getDoublebe
 
--- | Uses non-IEEE754 encoding. Does not round-trip NaN.
+-- | Uses IEEE754 encoding.
 instance Binary Float where
-    put f = put (decodeFloat f)
-    get   =  do
-        x <- get
-        y <- get
-        return $! encodeFloat x y
+    put = putFloatbe
+    get = getFloatbe
 
 ------------------------------------------------------------------------
 -- Trees


### PR DESCRIPTION
Fixes #64.
Fixes #69.